### PR TITLE
Add missing metadata in package.json in order to publish the api in npm

### DIFF
--- a/conf/npm/package-publish.json
+++ b/conf/npm/package-publish.json
@@ -1,8 +1,13 @@
 {
   "name": "arlas-tagger-api",
-  "version": "API_VERSION",
-  "description": "(Un)Tag fields of ARLAS collections",
+  "description": "Un)Tag fields of ARLAS collections.",
   "author": "Gisaia",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gisaia/ARLAS-tagger.git"
+  },
+  "version": "API_VERSION",
   "main": "./index.js",
   "typings": "./index.d.ts",
   "keywords": [


### PR DESCRIPTION
- The `package-publish.json` file needs the `"repository"` node to be set correctly in order to be able to publish the api in npm